### PR TITLE
chore: align Flutter metadata with iOS/Android-only project setup

### DIFF
--- a/.metadata
+++ b/.metadata
@@ -4,8 +4,8 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa"
-  channel: "stable"
+  revision: "9325183a877088484f61a82b09545540370ca93d"
+  channel: "beta"
 
 project_type: app
 
@@ -13,26 +13,14 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: 2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa
-      base_revision: 2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa
+      create_revision: 9325183a877088484f61a82b09545540370ca93d
+      base_revision: 9325183a877088484f61a82b09545540370ca93d
     - platform: android
-      create_revision: 2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa
-      base_revision: 2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa
+      create_revision: 9325183a877088484f61a82b09545540370ca93d
+      base_revision: 9325183a877088484f61a82b09545540370ca93d
     - platform: ios
-      create_revision: 2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa
-      base_revision: 2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa
-    - platform: linux
-      create_revision: 2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa
-      base_revision: 2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa
-    - platform: macos
-      create_revision: 2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa
-      base_revision: 2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa
-    - platform: web
-      create_revision: 2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa
-      base_revision: 2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa
-    - platform: windows
-      create_revision: 2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa
-      base_revision: 2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa
+      create_revision: 9325183a877088484f61a82b09545540370ca93d
+      base_revision: 9325183a877088484f61a82b09545540370ca93d
 
   # User provided section
 


### PR DESCRIPTION
## What changed:

Updated Flutter revision and channel entries in project metadata.
Removed unused platform migration entries for Linux, macOS, Web, and Windows.
Kept migration configuration focused on root, Android, and iOS.
## Why:

The repository now targets mobile platforms only.
Keeping metadata aligned with active platforms helps reduce noise from irrelevant generated artifacts and avoids confusion during local tooling updates.